### PR TITLE
Ruby variant of primes benchmark

### DIFF
--- a/prime_divisors/Rakefile
+++ b/prime_divisors/Rakefile
@@ -1,0 +1,6 @@
+task :c do
+  out = 'a.out'
+  sh "cc -o #{out} benchmark.c -O2"
+  sh "time ./#{out}"
+  rm out
+end

--- a/prime_divisors/Rakefile
+++ b/prime_divisors/Rakefile
@@ -4,3 +4,13 @@ task :c do
   sh "time ./#{out}"
   rm out
 end
+
+namespace :ruby do
+  task :test do
+    sh "ruby test_primes.rb"
+  end
+
+  task :bench do
+    sh "time ruby primes.rb"
+  end
+end

--- a/prime_divisors/benchmark.c
+++ b/prime_divisors/benchmark.c
@@ -49,5 +49,5 @@ int main(void)
     b = 10000000;
     k = 2;
     printf(" Number of integers between %d and %d, each having exactly %d prime divisors : %d" ,a,b,k,count(a,b,k));
-    return 1;
+    return 0;
 }

--- a/prime_divisors/benchmark.c
+++ b/prime_divisors/benchmark.c
@@ -48,6 +48,6 @@ int main(void)
     a = 2;
     b = 10000000;
     k = 2;
-    printf(" Number of integers between %d and %d, each having exactly %d prime divisors : %d" ,a,b,k,count(a,b,k));
+    printf(" Number of integers between %d and %d, each having exactly %d prime divisors : %d\n" ,a,b,k,count(a,b,k));
     return 0;
 }

--- a/prime_divisors/primes.rb
+++ b/prime_divisors/primes.rb
@@ -1,0 +1,25 @@
+def n_prime_divisors(n)
+  return 1 if n == 1
+  result = 2
+  d = 2
+  while d * d <= n
+    if n % d == 0
+      n /= d
+      result += 1
+    end
+    d += 1
+  end
+  result
+end
+
+def integers_having_prime_divisors(from, to, n_divisors)
+  (from..to).count do |i|
+    n_prime_divisors(i) == n_divisors
+  end
+end
+
+from = 2
+to = (ARGV.first || 10000000).to_i
+n_divisors = 2
+result = integers_having_prime_divisors(from, to, n_divisors)
+puts "#{from} #{to} #{n_divisors} #{result}"

--- a/prime_divisors/test_primes.rb
+++ b/prime_divisors/test_primes.rb
@@ -1,0 +1,18 @@
+require 'minitest/autorun'
+
+# Number of primes less than X
+# Source: https://primes.utm.edu/howmany.html#pi_def
+pi = {10 => 4,
+      100 => 25,
+      1_000 => 168,
+      10_000 => 1229,
+      100_000 => 9592}
+
+describe 'primes' do
+  it 'should match known counts' do
+    pi.each do |x, pi_x|
+      result = `ruby primes.rb #{x} | awk '{ print $4 }'`.chomp.to_i
+      assert_equal pi_x, result
+    end
+  end
+end


### PR DESCRIPTION
- https://github.com/zbard/benchmark/pull/1 is a prerequisite, because this PR assumes that the `Rakefile` is in place.
- For reference, here are the numbers on my machine (2012 MBP):

```
$ rake ruby:bench
time ruby primes.rb
2 10000000 2 664579
      421.14 real       419.73 user         0.31 sys
```
- The C program seems to be wrong (at least, as per this result - https://primes.utm.edu/howmany.html#pi_def).
