### PR TITLE
Improve readability of ruby prime divisors

### DIFF
--- a/prime_divisors/primes.rb
+++ b/prime_divisors/primes.rb
@@ -1,3 +1,17 @@
+# This program prints the value of "pi(n)", i.e. the numbers of primes
+# less than @p n.
+#
+# Arguments:
+#
+#     n: The number less than equal to which primes must be computed.
+#
+# Result:
+#
+#     n pi(n)
+#
+
+# @return The number of prime divisors of @p n.
+
 def n_prime_divisors(n)
   return 1 if n == 1
   result = 2
@@ -12,7 +26,10 @@ def n_prime_divisors(n)
   result
 end
 
-def integers_having_prime_divisors(from, to, n_divisors)
+# @return The numbers of integers between @p from and @p to (both
+# inclusive) having exactly @p n_divisors prime divisors.
+
+def n_nums_with_k_prime_divisors(from, to, n_divisors)
   result = 0
   (from..to).count do |i|
     if n_prime_divisors(i) == n_divisors
@@ -22,8 +39,18 @@ def integers_having_prime_divisors(from, to, n_divisors)
   result
 end
 
-from = 2
-to = (ARGV.first || 10000000).to_i
-n_divisors = 2
-result = integers_having_prime_divisors(from, to, n_divisors)
-puts "#{from} #{to} #{n_divisors} #{result}"
+# @return The number of primes between @p from and @p to (both inclusive).
+
+def n_primes(from, to)
+  n_nums_with_k_prime_divisors(from, to, 2)
+end
+
+# @return The number of primes less than or equal to @ n.
+
+def pi(n)
+  n_primes(2, n)
+end
+
+n = (ARGV.first || 10000000).to_i
+result = pi(n)
+puts "#{n} #{result}"

--- a/prime_divisors/test_primes.rb
+++ b/prime_divisors/test_primes.rb
@@ -11,7 +11,7 @@ pi = {10 => 4,
 describe 'primes' do
   it 'should match known counts' do
     pi.each do |x, pi_x|
-      result = `ruby primes.rb #{x} | awk '{ print $4 }'`.chomp.to_i
+      result = `ruby primes.rb #{x} | awk '{ print $2 }'`.chomp.to_i
       assert_equal pi_x, result
     end
   end


### PR DESCRIPTION
This commit also remove extraneous information from the output of the
program, at the cost of having its output differ from the C versions of
the same program.

Apart from the slightly different output format, there should be no functional changes in this PR. Provide me the output of the `rake ruby:test` command if it still fails.
